### PR TITLE
use date_to_datetime to prevent always getting date offsets west of UTC

### DIFF
--- a/sale_expected_delivery_date/__openerp__.py
+++ b/sale_expected_delivery_date/__openerp__.py
@@ -20,22 +20,29 @@
 ##############################################################################
 {
     'name': "Sale's Expected Delivery Date",
-    'version' : '0.1',
-    'author' : 'Ecosoft',
+    'version': '0.1',
+    'author': 'Ecosoft',
     'summary': "Force using SO's Expected Deivery Date in DO",
     'description': """
 This module provides "Expected Delivery Date" in Sales Order.
-This date will be used for DO's Scheduled Time instead of standard use of Product's customer lead time (will be ignored).    
-    """,
+This date will be used for DO's Scheduled Time instead of standard use of
+Product's customer lead time (will be ignored).
+""",
     'category': 'Sales Management',
-    'website' : 'http://ecosoft.co.th',
-    'images' : [],
-    'depends' : ['sale', 'sale_stock'],
-    'demo' : [],
-    'data' : [
-              'sale_view.xml',
-              ],
-    'test' : [],
+    'website': 'http://ecosoft.co.th',
+    'images': [],
+    'depends': [
+        'delivery',
+        'sale',
+        'sale_stock',
+    ],
+    'demo': [],
+    'data': [
+        'sale_view.xml',
+    ],
+    'test': [
+        'test/test_date_expected.yml',
+    ],
     'auto_install': False,
     'application': True,
     'installable': True,

--- a/sale_expected_delivery_date/sale.py
+++ b/sale_expected_delivery_date/sale.py
@@ -37,7 +37,7 @@ class sale_order(osv.osv):
 
     def _get_date_planned(self, cr, uid, order, line, start_date, context=None):
         # Overwrite with this date
-        return order.date_expected
+        return self.date_to_datetime(cr, uid, order.date_expected, context=context)
 
 sale_order()
 

--- a/sale_expected_delivery_date/sale.py
+++ b/sale_expected_delivery_date/sale.py
@@ -20,8 +20,6 @@
 ##############################################################################
 
 from openerp.osv import fields, osv
-import time
-import datetime
 
 
 class sale_order(osv.osv):
@@ -29,15 +27,19 @@ class sale_order(osv.osv):
     _inherit = "sale.order"
 
     _columns = {
-        'date_expected': fields.date('Expected Delivery Date', required=True, readonly=True, states={'draft': [('readonly', False)]}),
+        'date_expected': fields.date('Expected Delivery Date', required=True,
+                                     readonly=True,
+                                     states={'draft': [('readonly', False)]}),
     }
     _defaults = {
-        'date_expected': lambda *a: datetime.datetime.now().strftime('%Y-%m-%d'),
+        'date_expected': fields.date.today,
     }
 
-    def _get_date_planned(self, cr, uid, order, line, start_date, context=None):
+    def _get_date_planned(self, cr, uid, order, line, start_date,
+                          context=None):
         # Overwrite with this date
-        return self.date_to_datetime(cr, uid, order.date_expected, context=context)
+        return self.date_to_datetime(cr, uid, order.date_expected,
+                                     context=context)
 
 sale_order()
 

--- a/sale_expected_delivery_date/test/test_date_expected.yml
+++ b/sale_expected_delivery_date/test/test_date_expected.yml
@@ -1,0 +1,22 @@
+-
+  In order to test process of the Sale Order, I create sale order
+-
+  !record {model: sale.order, id: sale_order_test1}:
+    partner_id: base.res_partner_2
+    note: Invoice after delivery
+    payment_term: account.account_payment_term
+    order_line:
+      - product_id: product.product_product_7
+        product_uom_qty: 8
+        th_weight: 5.0
+    date_expected: 2014-12-25
+-
+  I confirm the sale order
+-
+  !workflow {model: sale.order, ref: sale_order_test1, action: order_confirm}
+-
+  I verify that there was a DO created, and it had the right scheduled date
+-
+  !assert {model: sale.order, id: sale_order_test1, string: The DO was not created with the right scheduled time}:
+    - picking_ids[0].min_date[:10] == '2014-12-25'
+


### PR DESCRIPTION
Because of the timezone handling by the clients, using the date directly makes the
min_date on stock moves always end up the day before for negative UTC offsets, since the
date is set to midnight, and then shown with an offset ends up the day before.

This causes us, at UTC-5, to have move and delivery orders planned at 19:00 the day before
the sale order expected date.
